### PR TITLE
Fix typo in link to quickstart

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,4 +8,4 @@ https://github.com/codingblocks/getting-started-with-skaffold
 https://skaffold.dev/docs/install/
 
 # Skaffold Quickstart
-https://skaffold.dev/docs/install/
+https://skaffold.dev/docs/quickstart/


### PR DESCRIPTION
Noticed a small typo in the quickstart link. Just had to create a PR for it right away. Great way to test the new GitHub web IDE.